### PR TITLE
Option to turn off storing files in the nested path.

### DIFF
--- a/lib/parklife/application.rb
+++ b/lib/parklife/application.rb
@@ -7,11 +7,12 @@ require 'parklife/utils'
 
 module Parklife
   class Application
-    attr_accessor :base, :build_dir, :rack_app, :reporter
+    attr_accessor :base, :build_dir, :nested_index, :rack_app, :reporter
 
-    def initialize(base: nil, build_dir: nil, rack_app: nil, reporter: NullReporter.new)
+    def initialize(base: nil, build_dir: nil, nested_index: false, rack_app: nil, reporter: NullReporter.new)
       @base = base
       @build_dir = build_dir
+      @nested_index = nested_index
       @rack_app = rack_app
       @reporter = reporter
       @after_build_callbacks = []
@@ -51,7 +52,13 @@ module Parklife
           raise HTTPError.new(path: route, status: session.status_code)
         end
 
-        session.save_page(Utils.build_path_for(dir: build_dir, path: route))
+        session.save_page(
+          Utils.build_path_for(
+            dir: build_dir,
+            index: nested_index,
+            path: route,
+          )
+        )
         reporter.print '.'
       end
 

--- a/lib/parklife/utils.rb
+++ b/lib/parklife/utils.rb
@@ -2,11 +2,16 @@ module Parklife
   module Utils
     extend self
 
-    def build_path_for(dir:, path:)
+    def build_path_for(dir:, path:, index: true)
       path = path.gsub(/^\/|\/$/, '')
 
       if File.extname(path).empty?
-        File.join(dir, path, 'index.html')
+        if index
+          File.join(dir, path, 'index.html')
+        else
+          name = path.empty? ? 'index.html' : "#{path}.html"
+          File.join(dir, name)
+        end
       else
         File.join(dir, path)
       end

--- a/spec/parklife/application_spec.rb
+++ b/spec/parklife/application_spec.rb
@@ -30,6 +30,33 @@ RSpec.describe Parklife::Application do
       end
     end
 
+    context 'when nested_index is false' do
+      let(:build_dir) { tmpdir }
+      let(:rack_app) { endpoint_200 }
+
+      it do
+        subject.nested_index = false
+        subject.routes do
+          get '/'
+          get '/foo'
+          get '/foo.xml'
+          get '/nested/foo'
+        end
+
+        subject.build
+
+        files = Dir.glob('**/*', base: tmpdir).sort
+
+        expect(files).to eql([
+          'foo.html',
+          'foo.xml',
+          'index.html',
+          'nested',
+          'nested/foo.html',
+        ])
+      end
+    end
+
     context 'when a base is defined' do
       let(:build_dir) { tmpdir }
       let(:rack_app) { Proc.new { |env| [200, {}, [env['rack.url_scheme'], ',', env['HTTP_HOST']]] } }

--- a/spec/parklife/utils_spec.rb
+++ b/spec/parklife/utils_spec.rb
@@ -2,36 +2,62 @@ require 'parklife/utils'
 
 RSpec.describe Parklife::Utils do
   describe '#build_path_for' do
-    subject { described_class.build_path_for(dir: dir, path: path) }
+    subject { described_class.build_path_for(dir: dir, path: path, index: index) }
 
-    context 'with the root path' do
-      let(:dir) { 'dist' }
-      let(:path) { '/' }
-      it { should eql('dist/index.html') }
+    context 'when index is true' do
+      let(:index) { true }
+
+      context 'with the root path' do
+        let(:dir) { 'dist' }
+        let(:path) { '/' }
+        it { should eql('dist/index.html') }
+      end
+
+      context 'with an expanded directory' do
+        let(:dir) { '/tmp/dist' }
+        let(:path) { '/' }
+        it { should eql('/tmp/dist/index.html') }
+      end
+
+      context 'with a nested path' do
+        let(:dir) { 'dist' }
+        let(:path) { '/bits/of/stuff' }
+        it { should eql('dist/bits/of/stuff/index.html') }
+      end
+
+      context 'with a nested directory with a no preceding slash' do
+        let(:dir) { 'dist' }
+        let(:path) { 'bits/of/stuff' }
+        it { should eql('dist/bits/of/stuff/index.html') }
+      end
+
+      context 'with an extension' do
+        let(:dir) { 'dist' }
+        let(:path) { '/some/path.json' }
+        it { should eql('dist/some/path.json') }
+      end
     end
 
-    context 'with an expanded directory' do
-      let(:dir) { '/tmp/dist' }
-      let(:path) { '/' }
-      it { should eql('/tmp/dist/index.html') }
-    end
+    context 'when index is false' do
+      let(:index) { false }
 
-    context 'with nested path' do
-      let(:dir) { 'dist' }
-      let(:path) { '/bits/of/stuff' }
-      it { should eql('dist/bits/of/stuff/index.html') }
-    end
+      context 'with the root path' do
+        let(:dir) { 'dist' }
+        let(:path) { '/' }
+        it { should eql('dist/index.html') }
+      end
 
-    context 'with a nested directory with a no preceding slash' do
-      let(:dir) { 'dist' }
-      let(:path) { 'bits/of/stuff' }
-      it { should eql('dist/bits/of/stuff/index.html') }
-    end
+      context 'with a nested path' do
+        let(:dir) { 'dist' }
+        let(:path) { '/bits/of/stuff' }
+        it { should eql('dist/bits/of/stuff.html') }
+      end
 
-    context 'with an extension' do
-      let(:dir) { 'dist' }
-      let(:path) { '/some/path.json' }
-      it { should eql('dist/some/path.json') }
+      context 'with an extension' do
+        let(:dir) { 'dist' }
+        let(:path) { '/some/path.json' }
+        it { should eql('dist/some/path.json') }
+      end
     end
   end
 end


### PR DESCRIPTION
By default Parklife stores files in an `index.html` file nested in the path -- so the route `/my/nested/route` is stored in `/my/nested/route/index.html`. This makes it possible to turn this off so that `/my/nested/route` is stored in `/my/nested/route.html`.
