### PR TITLE
Prevent Encoding::UndefinedConversionError error when writing response

### DIFF
--- a/lib/parklife/utils.rb
+++ b/lib/parklife/utils.rb
@@ -34,7 +34,7 @@ module Parklife
         build_path_for(path, index: config.nested_index)
       )
       FileUtils.mkdir_p(File.dirname(build_path))
-      File.write(build_path, content)
+      File.write(build_path, content, mode: 'wb')
     end
 
     def scan_for_links(html)


### PR DESCRIPTION
I'm seeing this error when trying to write a particular xlsx file:

    lib/parklife/utils.rb:37:in `write': "\\xEC" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)

The fix is simple but I can't seem to create a test case for it 🤷🏻‍♂️