### PR TITLE
Better Rails integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 gem 'bundler'
+gem 'rails'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ $ bundle exec parklife init
 Parklife is configured with a file called `Parkfile` in the root of your project, here's an example `Parkfile` for an imaginary Rails app:
 
 ```ruby
+# Load Parklife's Rails-specific integration which, among other things, allows
+# you to use URL helpers within the `routes` block below.
+require 'parklife/rails'
+
 # Load the Rails application, this gives you full access to the application's
 # environment from this file - using models for example.
 require_relative 'config/environment'
-
-# Load Parklife and some Rails-specific settings allowing you to use URL
-# helpers within the `routes` block below.
-require 'parklife/rails'
 
 Parkfile.application.routes do
   # Start from the homepage and crawl all links.

--- a/examples/rails/Parkfile
+++ b/examples/rails/Parkfile
@@ -1,5 +1,5 @@
-require_relative 'config/environment'
 require 'parklife/rails'
+require_relative 'config/environment'
 
 Parklife.application.configure do |config|
   # See configuration options here:

--- a/lib/parklife/errors.rb
+++ b/lib/parklife/errors.rb
@@ -16,10 +16,4 @@ module Parklife
       super %Q(Cannot load Parkfile "#{path}")
     end
   end
-
-  class RailsNotDefinedError < Error
-    def initialize(msg = 'Expected Rails to be defined, require config/environment before parklife')
-      super
-    end
-  end
 end

--- a/lib/parklife/rails.rb
+++ b/lib/parklife/rails.rb
@@ -20,6 +20,25 @@ module Parklife
   end
 
   class Railtie < Rails::Railtie
+    initializer 'parklife.disable_host_authorization' do |app|
+      # The offending middleware is included in Rails (6+) development mode and
+      # rejects a request with a 403 response if its host isn't present in the
+      # allowlist (a security feature). This prevents Parklife from working in
+      # a Rails app out of the box unless you manually add the expected
+      # Parklife base to the hosts allowlist or set it to nil to disable it -
+      # both of which aren't great because they disable the security feature
+      # whenever the development server is booted.
+      #
+      # https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization
+      #
+      # However it's safe to remove the middleware at this point because it
+      # won't be executed in the normal Rails development flow, only via a
+      # Parkfile when parklife/rails is required.
+      if defined?(ActionDispatch::HostAuthorization)
+        app.middleware.delete(ActionDispatch::HostAuthorization)
+      end
+    end
+
     config.after_initialize do
       Parklife.application.config.app = Rails.application
 

--- a/lib/parklife/rails.rb
+++ b/lib/parklife/rails.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-raise Parklife::RailsNotDefinedError unless defined?(Rails)
+require 'rails'
 
 module Parklife
   module RailsConfigRefinements
@@ -18,12 +18,16 @@ module Parklife
       }
     end
   end
+
+  class Railtie < Rails::Railtie
+    config.after_initialize do
+      Parklife.application.config.app = Rails.application
+
+      # Allow use of the Rails application's route helpers when defining
+      # Parklife routes in the block form.
+      Parklife.application.routes.singleton_class.include(Rails.application.routes.url_helpers)
+
+      Parklife.application.config.extend(RailsConfigRefinements)
+    end
+  end
 end
-
-Parklife.application.config.app = Rails.application
-
-# Allow use of the Rails application's route helpers when defining Parklife
-# routes in the block form.
-Parklife.application.routes.singleton_class.include(Rails.application.routes.url_helpers)
-
-Parklife.application.config.extend(Parklife::RailsConfigRefinements)

--- a/lib/parklife/templates/Parkfile.erb
+++ b/lib/parklife/templates/Parkfile.erb
@@ -1,6 +1,6 @@
 <% if options[:rails] -%>
-require_relative 'config/environment'
 require 'parklife/rails'
+require_relative 'config/environment'
 <% else -%>
 # Assuming your Rack app lives in ./app.rb:
 require_relative 'app'

--- a/spec/parklife/rails_spec.rb
+++ b/spec/parklife/rails_spec.rb
@@ -67,4 +67,8 @@ RSpec.describe 'Parklife Rails integration' do
       [rails_app.default_url_options, ActionController::Base.relative_url_root]
     }
   end
+
+  it 'removes host authorization middleware' do
+    expect(Rails.application.middleware).not_to include(ActionDispatch::HostAuthorization)
+  end
 end

--- a/spec/parklife/rails_spec.rb
+++ b/spec/parklife/rails_spec.rb
@@ -1,81 +1,70 @@
-require 'ostruct'
+require 'action_controller'
 require 'parklife/application'
+require 'parklife/rails'
 
 RSpec.describe 'Parklife Rails integration' do
-  let(:path_to_rails) { File.expand_path('../../lib/parklife/rails.rb', __dir__) }
-
-  context 'when Rails is defined' do
-    let(:action_controller_base) { OpenStruct.new }
-    let(:parklife_app) { Parklife::Application.new }
-    let(:rails) { double('Rails', application: rails_app) }
-    let(:rails_app) {
-      OpenStruct.new(
-        routes: OpenStruct.new(url_helpers: url_helpers),
-      )
-    }
-    let(:url_helpers) {
-      Module.new do
-        def foo_path
-          '/foo'
-        end
-      end
-    }
-
-    before do
-      stub_const('ActionController::Base', action_controller_base)
-      stub_const('Rails', rails)
-      allow(Parklife).to receive(:application).and_return(parklife_app)
-      load(path_to_rails)
+  let(:parklife_app) { Parklife::Application.new }
+  let(:rails_app) {
+    Class.new(Rails::Application) do
+      config.eager_load = false
+      config.logger = Logger.new('/dev/null')
     end
+  }
 
-    it 'gives access to Rails URL helpers when defining routes' do
-      parklife_app.routes do
-        get foo_path
-      end
-
-      route = Parklife::Route.new('/foo', crawl: false)
-      expect(parklife_app.routes).to include(route)
-
-      another_parklife_app = Parklife::Application.new
-
-      expect {
-        another_parklife_app.routes do
-          get foo_path
-        end
-      }.to raise_error(NameError, /foo_path/)
-    end
-
-    it 'configures Rails default_url_options and relative_url_root when setting Parklife base' do
-      parklife_app.config.base = 'https://localhost:3000/foo'
-
-      expect(rails_app.default_url_options).to eql({
-        host: 'localhost:3000',
-        protocol: 'https',
-      })
-      expect(action_controller_base.relative_url_root).to eql('/foo')
-
-      parklife_app.config.base = 'http://foo.example.com/'
-
-      expect(rails_app.default_url_options).to eql({
-        host: 'foo.example.com',
-        protocol: 'http',
-      })
-      expect(action_controller_base.relative_url_root).to be_nil
-
-      expect {
-        another_parklife_app = Parklife::Application.new
-        another_parklife_app.config.base = 'https://example.com/foo'
-      }.not_to change {
-        [rails_app.default_url_options, action_controller_base.relative_url_root]
-      }
-    end
+  before do
+    allow(Parklife).to receive(:application).and_return(parklife_app)
+    Rails.application = rails_app
+    Rails.application.initialize!
   end
 
-  context 'when Rails is not defined' do
-    it do
-      expect {
-        load(path_to_rails)
-      }.to raise_error(Parklife::RailsNotDefinedError)
+  after do
+    ActiveSupport::Dependencies.autoload_paths = []
+    ActiveSupport::Dependencies.autoload_once_paths = []
+  end
+
+  it 'gives access to Rails URL helpers when defining routes' do
+    rails_app.routes.draw do
+      get :foo, to: proc { [200, {}, 'foo'] }
     end
+
+    parklife_app.routes do
+      get foo_path
+    end
+
+    route = Parklife::Route.new('/foo', crawl: false)
+    expect(parklife_app.routes).to include(route)
+
+    another_parklife_app = Parklife::Application.new
+
+    expect {
+      another_parklife_app.routes do
+        get foo_path
+      end
+    }.to raise_error(NameError, /foo_path/)
+  end
+
+  it 'configures Rails default_url_options and relative_url_root when setting Parklife base' do
+    parklife_app.config.base = 'https://localhost:3000/foo'
+
+    expect(rails_app.default_url_options).to eql({
+      host: 'localhost:3000',
+      protocol: 'https',
+    })
+    expect(ActionController::Base.relative_url_root).to eql('/foo')
+
+    parklife_app.config.base = 'http://foo.example.com/'
+
+    expect(rails_app.default_url_options).to eql({
+      host: 'foo.example.com',
+      protocol: 'http',
+    })
+    expect(ActionController::Base.relative_url_root).to be_nil
+
+    expect {
+      another_parklife_app = Parklife::Application.new
+      another_parklife_app.config.base = 'https://example.com/foo'
+    }.not_to change {
+      [rails_app.default_url_options, ActionController::Base.relative_url_root]
+    }
   end
 end


### PR DESCRIPTION
Parklife now integrates with Rails via Railties and can therefore hook into its configuration before the app is initialised. This allows Parklife to remove the host authorisation middleware that's present in development and otherwise causes Parklife requests to receive a 403 response.