### PR TITLE
Crawl images and other HTML linked resources as well

### DIFF
--- a/lib/parklife/utils.rb
+++ b/lib/parklife/utils.rb
@@ -39,8 +39,17 @@ module Parklife
 
     def scan_for_links(html)
       doc = Nokogiri::HTML.parse(html)
-      doc.css('a').each do |a|
-        uri = URI.parse(a[:href])
+
+      # In this very exciting exercise we'll go through a list of elements to collect a list of candidate
+      # urls that *maybe* we'll want to crawl.
+      urls = doc.css('a').map { |v| v[:href] }
+      urls.concat(doc.css('img').map { |v| v[:src] })
+
+      # Source elements come in two flavors, for images the srcset attribute is used, for audio / video the src is used
+      urls.concat(doc.css('source').map { |v| [v[:srcset], v[:src]].compact.reject(&:empty?).first })
+
+      urls.each do |url|
+        uri = URI.parse(url)
 
         # Don't visit a URL that belongs to a different domain - for now this is
         # a guess that it's not an internal link but it also covers mailto/ftp

--- a/spec/parklife/utils_spec.rb
+++ b/spec/parklife/utils_spec.rb
@@ -144,6 +144,12 @@ RSpec.describe Parklife::Utils do
         ❌ <a href="">empty</a>
         ✅ <a href="/baz">baz</a>
         ❌ <a href="ftp://example.com/foo/bar">ftp</a>
+
+        ✅ <img src="/foo.jpg" alt="Foo is life">
+        ❌ <img src="https://www.example.com/foo.jpg" alt="Foo is life">
+
+        ✅ <audio><source src="/foo.mp3" type="audio/mp3"></audio>
+        ✅ <picture><source srcset="/foo.webp"><source srcset="/foo-squared.jpg"><img src="/default-foo.jpg"></picture>
       HTML
     }
 
@@ -153,7 +159,14 @@ RSpec.describe Parklife::Utils do
       }.to yield_successive_args(
         '/foo',
         '/bar',
-        '/baz'
+        '/baz',
+
+        '/foo.jpg',
+        '/default-foo.jpg',
+
+        '/foo.mp3',
+        '/foo.webp',
+        '/foo-squared.jpg',
       )
     end
   end


### PR DESCRIPTION
A small follow up to https://github.com/benpickles/parklife/issues/102 where I was trying to figure out the best strategy to include `ActiveStorage` attachments into the static build. 

TL;DR; I first tried to generate and copy the attachment files via a rake task but there are - to the best of my present knowledge - quite a few hoops to jump through to get the *right* final URL so that it matches what the markup expects, so much so that I think it's extremely error prone. The other option I explored was for `parklife` to merely collect more URLs and - maybe - get and save those files, which I ended up doing in  `Utils#scan_for_links`

The code is simple enough but I'm unsure what scenarios exist that might hamper this approach, so I though I would open a PR just the same as that makes discussion easier .. maybe :)