### PR TITLE
Skip `a` elements without an `href` attribute

### DIFF
--- a/lib/parklife/utils.rb
+++ b/lib/parklife/utils.rb
@@ -40,6 +40,9 @@ module Parklife
     def scan_for_links(html)
       doc = Nokogiri::HTML.parse(html)
       doc.css('a').each do |a|
+        # Skip if there is no href attribute
+        next unless a[:href]
+
         uri = URI.parse(a[:href])
 
         # Don't visit a URL that belongs to a different domain - for now this is

--- a/lib/parklife/utils.rb
+++ b/lib/parklife/utils.rb
@@ -39,10 +39,7 @@ module Parklife
 
     def scan_for_links(html)
       doc = Nokogiri::HTML.parse(html)
-      doc.css('a').each do |a|
-        # Skip if there is no href attribute
-        next unless a[:href]
-
+      doc.css('a[href]').each do |a|
         uri = URI.parse(a[:href])
 
         # Don't visit a URL that belongs to a different domain - for now this is

--- a/spec/parklife/utils_spec.rb
+++ b/spec/parklife/utils_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe Parklife::Utils do
         ❌ <a href="">empty</a>
         ✅ <a href="/baz">baz</a>
         ❌ <a href="ftp://example.com/foo/bar">ftp</a>
+        ❌ <a>no-href</a>
       HTML
     }
 


### PR DESCRIPTION
Fixes #106, though slightly roundabout by instead just ignoring `a` tags without an `href` attribute (which are [apparently valid](https://html.spec.whatwg.org/#attr-hyperlink-href))