### PR TITLE
Apply Rails default_url_options, relative_url_root, and force_ssl settings to Parklife's base

### DIFF
--- a/examples/rails/config/environments/production.rb
+++ b/examples/rails/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/lib/parklife/rails.rb
+++ b/lib/parklife/rails.rb
@@ -8,7 +8,7 @@ module Parklife
     # default_url_options and relative_url_root to match.
     def base=(value)
       super.tap { |uri|
-        Rails.application.default_url_options = {
+        app.default_url_options = {
           host: Utils.host_with_port(uri),
           protocol: uri.scheme,
         }

--- a/lib/parklife/rails.rb
+++ b/lib/parklife/rails.rb
@@ -43,15 +43,13 @@ module Parklife
       if defined?(ActionDispatch::HostAuthorization)
         app.middleware.delete(ActionDispatch::HostAuthorization)
       end
-    end
 
-    config.after_initialize do
-      Parklife.application.config.app = Rails.application
+      Parklife.application.config.app = app
 
       # Allow use of the Rails application's route helpers when defining
       # Parklife routes in the block form.
       Parklife.application.routes.singleton_class.include(RailsRouteSetRefinements)
-      Parklife.application.routes.singleton_class.include(Rails.application.routes.url_helpers)
+      Parklife.application.routes.singleton_class.include(app.routes.url_helpers)
 
       Parklife.application.config.extend(RailsConfigRefinements)
     end

--- a/lib/parklife/rails.rb
+++ b/lib/parklife/rails.rb
@@ -53,5 +53,17 @@ module Parklife
 
       Parklife.application.config.extend(RailsConfigRefinements)
     end
+
+    config.after_initialize do |app|
+      # Read the Rails app's URL config and apply it to Parklife's so that the
+      # Rails config can be used as the single source of truth.
+      host, protocol = app.default_url_options.values_at(:host, :protocol)
+      protocol = 'https' if app.config.force_ssl
+      path = ActionController::Base.relative_url_root
+
+      Parklife.application.config.base.scheme = protocol if protocol
+      Parklife.application.config.base.host = host if host
+      Parklife.application.config.base.path = path if path
+    end
   end
 end

--- a/spec/parklife/rails_spec.rb
+++ b/spec/parklife/rails_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Parklife Rails integration' do
   let(:parklife_app) { Parklife::Application.new }
   let(:rails_app) {
     Class.new(Rails::Application) do
+      config.active_support.to_time_preserves_timezone = :zone
       config.eager_load = false
       config.logger = Logger.new('/dev/null')
     end

--- a/spec/parklife/rails_spec.rb
+++ b/spec/parklife/rails_spec.rb
@@ -12,18 +12,24 @@ RSpec.describe 'Parklife Rails integration' do
     end
   }
 
+  def initialize!
+    rails_app.initialize!
+  end
+
   before do
     allow(Parklife).to receive(:application).and_return(parklife_app)
     Rails.application = rails_app
-    Rails.application.initialize!
   end
 
   after do
+    ActionController::Base.relative_url_root = nil
     ActiveSupport::Dependencies.autoload_paths = []
     ActiveSupport::Dependencies.autoload_once_paths = []
   end
 
   it 'gives access to Rails URL helpers when defining routes' do
+    initialize!
+
     rails_app.routes.draw do
       get :foo, to: proc { [200, {}, 'foo'] }
     end
@@ -45,6 +51,8 @@ RSpec.describe 'Parklife Rails integration' do
   end
 
   it 'configures Rails default_url_options and relative_url_root when setting Parklife base' do
+    initialize!
+
     parklife_app.config.base = 'https://localhost:3000/foo'
 
     expect(rails_app.default_url_options).to eql({
@@ -70,6 +78,42 @@ RSpec.describe 'Parklife Rails integration' do
   end
 
   it 'removes host authorization middleware' do
+    initialize!
+
     expect(Rails.application.middleware).not_to include(ActionDispatch::HostAuthorization)
+  end
+
+  context 'setting the Parklife base from Rails config on initialize' do
+    it 'uses Parklife defaults when nothing is set' do
+      initialize!
+
+      expect(parklife_app.config.base).to have_attributes(
+        host: 'example.com',
+        path: '',
+        scheme: 'http',
+      )
+    end
+
+    it 'copies the values from default_url_options and relative_url_root' do
+      rails_app.default_url_options = { host: 'foo', protocol: 'bar' }
+      ActionController::Base.relative_url_root = '/baz'
+
+      initialize!
+
+      expect(parklife_app.config.base).to have_attributes(
+        host: 'foo',
+        path: '/baz',
+        scheme: 'bar',
+      )
+    end
+
+    it 'always uses https if force_ssl=true' do
+      rails_app.default_url_options = { protocol: 'foo' }
+      rails_app.config.force_ssl = true
+
+      initialize!
+
+      expect(parklife_app.config.base.scheme).to eql('https')
+    end
   end
 end


### PR DESCRIPTION
This makes it so the default Rails production setting of `force_ssl=true` is automatically applied to Parklife's base which prevents `301` responses when running the default `bin/static-build` (#116), it also applies `default_url_options` and `relative_url_root` if they're defined. Setting a `base` in the `Parkfile` or via `--base` with the CLI will override these Rails-applied defaults.
