### PR TITLE
If the build directory already exists only remove its contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Parklife.application.config.nested_index = false
 
 ### Changing the build output directory
 
-The build directory shouldn't exist and is destroyed and recreated before each build. Defaults to `build`.
+The build directory's contents are removed before each build. Defaults to `build`.
 
 ```ruby
 Parklife.application.config.build_dir = 'my/build/dir'

--- a/lib/parklife/application.rb
+++ b/lib/parklife/application.rb
@@ -29,8 +29,16 @@ module Parklife
       raise BuildDirNotDefinedError if config.build_dir.nil?
       raise RackAppNotDefinedError if config.app.nil?
 
-      FileUtils.rm_rf(config.build_dir)
-      Dir.mkdir(config.build_dir)
+      if Dir.exist?(config.build_dir)
+        FileUtils.rm_rf(
+          Dir.glob(
+            File.join(config.build_dir, '*'),
+            File::FNM_DOTMATCH
+          )
+        )
+      else
+        Dir.mkdir(config.build_dir)
+      end
 
       @before_build_callbacks.each do |callback|
         callback.call(self)

--- a/spec/parklife/application_spec.rb
+++ b/spec/parklife/application_spec.rb
@@ -28,6 +28,39 @@ RSpec.describe Parklife::Application do
       end
     end
 
+    context 'when config.build_dir does not exist' do
+      let(:app) { endpoint_200 }
+      let(:build_dir) { File.join(tmpdir, 'foo') }
+
+      it 'it is created' do
+        expect {
+          subject.build
+        }.to change {
+          Dir.exist?(build_dir)
+        }.to(true)
+      end
+    end
+
+    context 'when config.build_dir already exists' do
+      let(:app) { endpoint_200 }
+      let(:build_dir) { tmpdir }
+
+      it 'it remains and its contents are removed' do
+        FileUtils.touch(File.join(tmpdir, 'foo.html'))
+        FileUtils.mkdir_p(File.join(tmpdir, 'nested', 'directory'))
+        FileUtils.touch(File.join(tmpdir, 'nested', 'directory', 'bar.html'))
+        FileUtils.touch(File.join(tmpdir, '.hidden'))
+
+        expect {
+          subject.build
+        }.not_to change {
+          File.stat(tmpdir).ino
+        }
+
+        expect(Dir.glob('**/*', File::FNM_DOTMATCH, base: tmpdir)).to eql(['.'])
+      end
+    end
+
     context 'when config.app is not set' do
       let(:app) { nil }
       let(:build_dir) { tmpdir }


### PR DESCRIPTION
It makes life much easier when testing a build locally if you can remain in the same directory.