### PR TITLE
Add inter-build caching via support HTTP ETags

### DIFF
--- a/lib/parklife/application.rb
+++ b/lib/parklife/application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'parklife/build'
 require 'parklife/config'
 require 'parklife/crawler'
 require 'parklife/errors'
@@ -50,7 +51,11 @@ module Parklife
     end
 
     def crawler
-      @crawler ||= Crawler.new(config, @route_set)
+      @crawler ||= Crawler.new(
+        config,
+        @route_set,
+        config.cache_dir ? Build.from_dir(config.cache_dir) : nil
+      )
     end
 
     def load_Parkfile(path)

--- a/lib/parklife/application.rb
+++ b/lib/parklife/application.rb
@@ -29,11 +29,8 @@ module Parklife
     def build
       raise RackAppNotDefinedError if config.app.nil?
 
-      if config.build_dir.directory?
-        FileUtils.rm_rf(config.build_dir.children)
-      else
-        config.build_dir.mkdir
-      end
+      prepare_cache_dir if config.cache_dir
+      prepare_build_dir
 
       @before_build_callbacks.each do |callback|
         callback.call(self)
@@ -70,5 +67,37 @@ module Parklife
         @route_set
       end
     end
+
+    private
+      def prepare_build_dir
+        if config.build_dir.directory?
+          FileUtils.rm_rf(config.build_dir.children)
+        else
+          config.build_dir.mkdir
+        end
+      end
+
+      def prepare_cache_dir
+        # Nothing to do unless the previous build is being used as a cache.
+        return unless config.cache_dir.expand_path == config.build_dir.expand_path
+
+        if config.build_dir.exist?
+          config.cache_dir = Config::CACHE_TMPDIR
+
+          if config.cache_dir.exist?
+            config.cache_dir.rmtree
+          else
+            config.cache_dir.dirname.mkpath
+          end
+
+          # Move the existing previous build to the tmp location to clear the
+          # way for a fresh new build.
+          config.build_dir.rename(config.cache_dir)
+        else
+          # The build/cache directories are set to the same thing but don't
+          # exist so there is no cache.
+          config.cache_dir = nil
+        end
+      end
   end
 end

--- a/lib/parklife/browser.rb
+++ b/lib/parklife/browser.rb
@@ -11,24 +11,23 @@ module Parklife
       @app = app
       @base = base
       @session = Rack::Test::Session.new(app)
-      set_env
+      @env = {
+        'HTTP_HOST' => Utils.host_with_port(base),
+        'HTTPS' => base.scheme == 'https' ? 'on' : 'off',
+        script_name: base.path.chomp('/'),
+      }
     end
 
-    def get(path)
-      session.get(path, nil, env)
+    def get(path, headers: nil)
+      session.get(
+        path,
+        nil,
+        headers ? headers.merge(env) : env
+      )
     end
 
     def uri_for(path)
       base.dup.tap { |uri| uri.path = path }
     end
-
-    private
-      def set_env
-        @env = {
-          'HTTP_HOST' => Utils.host_with_port(base),
-          'HTTPS' => base.scheme == 'https' ? 'on' : 'off',
-          script_name: base.path.chomp('/'),
-        }
-      end
   end
 end

--- a/lib/parklife/build.rb
+++ b/lib/parklife/build.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+require 'yaml'
+
 module Parklife
   class Build
+    META_PATH = File.join('.parklife', 'build.yml')
+
     def self.path_for(path, media_type: nil, nested_index:)
       # Remove leading/trailing slashes.
       path = path.gsub(/^\/|\/$/, '')
@@ -23,11 +27,12 @@ module Parklife
       path
     end
 
-    attr_reader :dir, :nested_index
+    attr_reader :dir, :nested_index, :paths
 
     def initialize(dir, nested_index:)
       @dir = dir
       @nested_index = nested_index
+      @paths = {}
     end
 
     def add(route, response)
@@ -36,10 +41,27 @@ module Parklife
         media_type: response.media_type,
         nested_index: nested_index,
       )
+      write(build_path, response.body)
+      paths[route.path] = { 'build_path' => build_path }.compact
+    end
 
-      file = dir.join(build_path)
+    def to_yaml
+      YAML.dump({
+        'config' => {
+          'nested_index' => nested_index,
+        },
+        'paths' => paths,
+      })
+    end
+
+    def write(path, content)
+      file = dir.join(path)
       file.dirname.mkpath
-      file.write(response.body, mode: 'wb')
+      file.write(content, mode: 'wb')
+    end
+
+    def write_meta
+      write(META_PATH, to_yaml)
     end
   end
 end

--- a/lib/parklife/build.rb
+++ b/lib/parklife/build.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
+require 'fileutils'
 require 'yaml'
 
 module Parklife
   class Build
     META_PATH = File.join('.parklife', 'build.yml')
+
+    def self.from_dir(dir)
+      return unless dir.exist?
+      path = dir.join(META_PATH)
+      return unless path.exist?
+      data = YAML.safe_load(path.read)
+
+      build = new(dir, nested_index: data.dig('config', 'nested_index'))
+      build.paths.merge!(data['paths'])
+      build
+    end
 
     def self.path_for(path, media_type: nil, nested_index:)
       # Remove leading/trailing slashes.
@@ -36,13 +48,35 @@ module Parklife
     end
 
     def add(route, response)
-      build_path = self.class.path_for(
+      build_path = self.build_path(route, response)
+      write(build_path, response.body)
+      add_path_meta(route, response, build_path)
+    end
+
+    def build_path(route, response)
+      self.class.path_for(
         route.path,
         media_type: response.media_type,
         nested_index: nested_index,
       )
-      write(build_path, response.body)
-      paths[route.path] = { 'build_path' => build_path }.compact
+    end
+
+    def copy(src, route, response)
+      build_path = self.build_path(route, response)
+
+      dest = dir.join(build_path)
+      dest.dirname.mkpath
+      FileUtils.cp(src, dest)
+
+      add_path_meta(route, response, build_path)
+    end
+
+    def etag(path)
+      paths.dig(path, 'etag')
+    end
+
+    def get(route, response)
+      dir.join(build_path(route, response))
     end
 
     def to_yaml
@@ -63,5 +97,13 @@ module Parklife
     def write_meta
       write(META_PATH, to_yaml)
     end
+
+    private
+      def add_path_meta(route, response, build_path)
+        paths[route.path] = {
+          'build_path' => build_path,
+          'etag' => response['Etag'],
+        }.compact
+      end
   end
 end

--- a/lib/parklife/cli.rb
+++ b/lib/parklife/cli.rb
@@ -11,8 +11,10 @@ module Parklife
     class_option :base, desc: 'Override config.base configured in the Parkfile'
 
     desc 'build', 'Create a production build'
+    option :cache_dir, desc: 'Path to an existing build directory (must include build meta)', type: :string
     option :skip_build_meta, desc: 'Do not include Parklife build metadata', type: :boolean
     def build
+      application.config.cache_dir = options[:cache_dir] if options.key?(:cache_dir)
       application.config.skip_build_meta = options[:skip_build_meta] if options.key?(:skip_build_meta)
       application.build
     end

--- a/lib/parklife/cli.rb
+++ b/lib/parklife/cli.rb
@@ -11,7 +11,9 @@ module Parklife
     class_option :base, desc: 'Override config.base configured in the Parkfile'
 
     desc 'build', 'Create a production build'
+    option :skip_build_meta, desc: 'Do not include Parklife build metadata', type: :boolean
     def build
+      application.config.skip_build_meta = options[:skip_build_meta] if options.key?(:skip_build_meta)
       application.build
     end
 

--- a/lib/parklife/config.rb
+++ b/lib/parklife/config.rb
@@ -5,6 +5,7 @@ require 'uri'
 
 module Parklife
   class Config
+    CACHE_TMPDIR = 'tmp/parklife/cache'
     DEFAULT_HOST = 'example.com'
     DEFAULT_SCHEME = 'http'
 

--- a/lib/parklife/config.rb
+++ b/lib/parklife/config.rb
@@ -8,7 +8,7 @@ module Parklife
     DEFAULT_HOST = 'example.com'
     DEFAULT_SCHEME = 'http'
 
-    attr_accessor :app, :nested_index, :on_404, :reporter
+    attr_accessor :app, :nested_index, :on_404, :reporter, :skip_build_meta
     attr_reader :base, :build_dir
 
     def initialize
@@ -17,6 +17,7 @@ module Parklife
       self.nested_index = true
       self.on_404 = :error
       self.reporter = StringIO.new
+      self.skip_build_meta = false
     end
 
     def base=(value)

--- a/lib/parklife/config.rb
+++ b/lib/parklife/config.rb
@@ -9,11 +9,12 @@ module Parklife
     DEFAULT_SCHEME = 'http'
 
     attr_accessor :app, :nested_index, :on_404, :reporter, :skip_build_meta
-    attr_reader :base, :build_dir
+    attr_reader :base, :build_dir, :cache_dir
 
     def initialize
       self.base = nil
       self.build_dir = 'build'
+      self.cache_dir = nil
       self.nested_index = true
       self.on_404 = :error
       self.reporter = StringIO.new
@@ -29,6 +30,10 @@ module Parklife
 
     def build_dir=(value)
       @build_dir = Pathname.new(value)
+    end
+
+    def cache_dir=(value)
+      @cache_dir = value ? Pathname.new(value) : nil
     end
   end
 end

--- a/lib/parklife/crawler.rb
+++ b/lib/parklife/crawler.rb
@@ -47,6 +47,8 @@ module Parklife
         config.reporter.print('.')
       end
 
+      build.write_meta unless config.skip_build_meta
+
       config.reporter.puts
     end
 

--- a/lib/parklife/crawler.rb
+++ b/lib/parklife/crawler.rb
@@ -3,10 +3,12 @@ require 'set'
 require_relative 'browser'
 require_relative 'build'
 require_relative 'responder/not_found'
+require_relative 'responder/not_modified'
 require_relative 'responder/ok'
 require_relative 'responder/redirect'
 require_relative 'responder/unknown'
 require_relative 'route'
+require_relative 'utils'
 
 module Parklife
   class Crawler
@@ -14,22 +16,49 @@ module Parklife
       200 => Responder::Ok,
       301 => Responder::Redirect,
       302 => Responder::Redirect,
+      304 => Responder::NotModified,
       404 => Responder::NotFound,
     }
 
-    attr_reader :browser, :build, :config, :routes, :visited
+    attr_reader :browser, :build, :cache, :config, :routes, :visited
 
-    def initialize(config, routes)
+    def initialize(config, routes, cache)
       @config = config
       @routes = routes.to_a
+      @cache = cache
       @browser = Browser.new(config.app, config.base)
       @build = Build.new(config.build_dir, nested_index: config.nested_index)
       @visited = Set.new
       @responder_for_status = {}
     end
 
+    def crawl(html)
+      Utils.scan_for_links(html) do |path|
+        # If the app is mounted at a subdirectory then it responds to paths that
+        # *exclude* the subdirectory and generates links that *include* the
+        # subdirectory (so if the app is mounted at "/foo" and serving "/bar"
+        # then the full path would be "/foo/bar" and a generated link would
+        # include the mount path like "/foo/link").
+        #
+        # Anyway, this mount path prefix must be trimmed from link paths so that
+        # correct app routes are created.
+        baseless_path = path.delete_prefix(config.base.path)
+        new_route = Route.new(baseless_path, crawl: true)
+
+        next if visited?(new_route)
+
+        routes << new_route
+      end
+    end
+
     def get(path)
-      browser.get(path)
+      headers = if (etag = cache&.etag(path))
+        { 'HTTP_IF_NONE_MATCH' => etag }
+      else
+        nil
+      end
+
+      browser.get(path, headers: headers)
     end
 
     def responder_for_status(status)

--- a/lib/parklife/responder/not_modified.rb
+++ b/lib/parklife/responder/not_modified.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require_relative 'base'
+
+module Parklife
+  module Responder
+    class NotModified < Base
+      def call(route, response)
+        pathname = crawler.cache&.get(route, response)
+
+        return unless pathname&.exist?
+
+        crawler.build.copy(pathname, route, response)
+        crawler.crawl(pathname.read) if route.crawl
+      end
+    end
+  end
+end

--- a/lib/parklife/responder/ok.rb
+++ b/lib/parklife/responder/ok.rb
@@ -1,32 +1,12 @@
 # frozen_string_literal: true
 require_relative 'base'
-require_relative '../route'
-require_relative '../utils'
 
 module Parklife
   module Responder
     class Ok < Base
       def call(route, response)
         crawler.build.add(route, response)
-
-        return unless route.crawl
-
-        Utils.scan_for_links(response.body) do |path|
-          # If the app is mounted at a subdirectory then it responds to paths
-          # that *exclude* the subdirectory and generates links that *include*
-          # the subdirectory (so if the app is mounted at "/foo" and serving
-          # "/bar" then the full path would be "/foo/bar" and a generated link
-          # would include the mount path like "/foo/link").
-          #
-          # Anyway, this mount path prefix must be trimmed from link paths so
-          # that correct app routes are created.
-          baseless_path = path.delete_prefix(crawler.config.base.path)
-          new_route = Route.new(baseless_path, crawl: true)
-
-          next if crawler.visited?(new_route)
-
-          crawler.routes << new_route
-        end
+        crawler.crawl(response.body) if route.crawl
       end
     end
   end

--- a/spec/parklife/application_spec.rb
+++ b/spec/parklife/application_spec.rb
@@ -1,24 +1,21 @@
-require 'parklife/application'
+require 'digest'
 require 'tmpdir'
+require 'parklife/application'
 
 RSpec.describe Parklife::Application do
   describe '#build' do
-    let(:endpoint_200) { Proc.new { [200, {}, ['200']] } }
-    let(:endpoint_302) { Proc.new { [302, { 'Location' => 'http://example.com/' }, ['302']] } }
-    let(:endpoint_500) { Proc.new { [500, {}, ['500']] } }
+    subject(:application) { described_class.new }
+
+    let(:app) { Proc.new { [200, {}, ['200']] } }
+    let(:config) { application.config }
     let(:tmpdir) { Dir.mktmpdir }
 
-    subject {
-      described_class.new.tap { |application|
-        application.configure do |config|
-          config.app = app
-          config.build_dir = build_dir
-        end
-      }
-    }
+    before do
+      config.app = app
+      config.build_dir = build_dir
+    end
 
     context 'when config.build_dir does not exist' do
-      let(:app) { endpoint_200 }
       let(:build_dir) { File.join(tmpdir, 'foo') }
 
       it 'it is created' do
@@ -31,7 +28,6 @@ RSpec.describe Parklife::Application do
     end
 
     context 'when config.build_dir already exists' do
-      let(:app) { endpoint_200 }
       let(:build_dir) { tmpdir }
 
       it 'remains but its contents are removed' do
@@ -64,7 +60,6 @@ RSpec.describe Parklife::Application do
     end
 
     context 'with callbacks' do
-      let(:app) { endpoint_200 }
       let(:build_dir) { tmpdir }
 
       it 'they are called in the correct order' do
@@ -76,6 +71,133 @@ RSpec.describe Parklife::Application do
         subject.build
 
         expect(stuff).to eql([1, 2])
+      end
+    end
+
+    context 'when build_dir and cache_dir are the same (i.e. the previous build is used as the cache)' do
+      let(:app) {
+        Proc.new { |env|
+          html = case env['PATH_INFO']
+          when '/'
+            '<a href="/foo">foo</a>'
+          when '/foo'
+            foo_body
+          else
+            '200'
+          end
+
+          etag = Digest::MD5.hexdigest(html)
+          headers = { 'etag' => etag }
+
+          if env['HTTP_IF_NONE_MATCH'] == etag
+            [304, headers, ['']]
+          else
+            [200, headers, [html]]
+          end
+        }
+      }
+      let(:build_dir) { 'build' }
+      let(:cache_dir) { build_dir }
+      let(:foo_body) { 'foo' }
+
+      around do |example|
+        Dir.chdir(tmpdir) do
+          config.cache_dir = cache_dir
+          subject.routes.root crawl: true
+          example.run
+        end
+      end
+
+      context 'and build_dir/cache_dir exist' do
+        before do
+          config.build_dir.mkpath
+        end
+
+        context 'and includes build metadata' do
+          before do
+            build = Parklife::Build.new(
+              config.build_dir,
+              nested_index: config.nested_index,
+            )
+            build.add(
+              Parklife::Route.new('/foo', crawl: false),
+              Rack::MockResponse.new(
+                200,
+                { 'etag' => Digest::MD5.hexdigest(foo_body) },
+                '<a href="/bar">bar</a>' # Link to another page in the cache.
+              )
+
+            )
+            build.write_meta
+          end
+
+          context 'and the tmp cache directory does not already exist' do
+            it 'the previous build is moved to a tmp directory and used as the cache_dir' do
+              subject.build
+
+              expect(build_files).to contain_exactly(
+                '.parklife/build.yml',
+                'bar/index.html', # Page linked from cache.
+                'foo/index.html',
+                'index.html',
+              )
+            end
+          end
+
+          context 'but the tmp cache directory already exists' do
+            before do
+              cache_tmpdir = Parklife::Config::CACHE_TMPDIR
+              FileUtils.mkpath(cache_tmpdir)
+              FileUtils.touch(File.join(cache_tmpdir, 'delete-me.html'))
+            end
+
+            it 'the tmp cache directory is replaced by the existing build/cache and used as the cache_dir' do
+              subject.build
+
+              expect(build_files).to contain_exactly(
+                '.parklife/build.yml',
+                'bar/index.html', # Page linked from cache.
+                'foo/index.html',
+                'index.html',
+              )
+            end
+          end
+
+          context 'when build_dir/cache_dir point to the same directory but are formatted differently' do
+            let(:cache_dir) { './build/' }
+
+            it 'recognises that the paths match and works as expected' do
+              subject.build
+
+              expect(build_files).to contain_exactly(
+                '.parklife/build.yml',
+                'bar/index.html', # Page linked from cache.
+                'foo/index.html',
+                'index.html',
+              )
+            end
+          end
+        end
+
+        context 'but does not include build metadata' do
+          it 'builds without the cache' do
+            subject.build
+
+            expect(build_files).to contain_exactly(
+              '.parklife/build.yml',
+              'foo/index.html',
+              'index.html',
+            )
+          end
+        end
+      end
+
+      context 'but build_dir/cache_dir does not exist' do
+        it 'cache_dir is unset' do
+          subject.build
+
+          expect(subject.config.cache_dir).to be_nil
+        end
       end
     end
   end

--- a/spec/parklife/application_spec.rb
+++ b/spec/parklife/application_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Parklife::Application do
       let(:app) { endpoint_200 }
       let(:build_dir) { tmpdir }
 
-      it 'it remains and its contents are removed' do
+      it 'remains but its contents are removed' do
+        subject.config.skip_build_meta = true
+
         FileUtils.touch(File.join(tmpdir, 'foo.html'))
         FileUtils.mkdir_p(File.join(tmpdir, 'nested', 'directory'))
         FileUtils.touch(File.join(tmpdir, 'nested', 'directory', 'bar.html'))

--- a/spec/parklife/browser_spec.rb
+++ b/spec/parklife/browser_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe Parklife::Browser do
           env['rack.url_scheme'],
           env['HTTP_HOST'],
           env['PATH_INFO'],
-          request.url
-        ].join(',')
+          request.url,
+          request.get_header('HTTP_IF_NONE_MATCH'),
+          request.get_header('HTTP_FOO'),
+        ].compact.join("\n")
 
         [status, {}, [body]]
       }
@@ -29,11 +31,25 @@ RSpec.describe Parklife::Browser do
 
       it do
         response = browser.get('/foo')
-        expect(response.body).to eql('http,example.com,/foo,http://example.com/foo')
+        expect(response.body).to eql(
+          <<~TEXT.chomp
+            http
+            example.com
+            /foo
+            http://example.com/foo
+          TEXT
+        )
         expect(response.status).to eql(200)
 
         response = browser.get('/404')
-        expect(response.body).to eql('http,example.com,/404,http://example.com/404')
+        expect(response.body).to eql(
+          <<~TEXT.chomp
+            http
+            example.com
+            /404
+            http://example.com/404
+          TEXT
+        )
         expect(response.status).to eql(404)
       end
     end
@@ -43,16 +59,52 @@ RSpec.describe Parklife::Browser do
 
       it 'strips it from the passed path' do
         response = browser.get('/baz')
-        expect(response.body).to eql('https,foo.example.com,/baz,https://foo.example.com/bar/baz')
+        expect(response.body).to eql(
+          <<~TEXT.chomp
+            https
+            foo.example.com
+            /baz
+            https://foo.example.com/bar/baz
+          TEXT
+        )
       end
     end
 
-    context 'when the base has a non-standard port' do
+    context 'when the base has a non-standard port', :focus do
       let(:base) { URI.parse('http://localhost:3000') }
 
       it do
         response = browser.get('/foo')
-        expect(response.body).to eql('http,localhost:3000,/foo,http://localhost:3000/foo')
+        expect(response.body).to eql(
+          <<~TEXT.chomp
+            http
+            localhost:3000
+            /foo
+            http://localhost:3000/foo
+          TEXT
+        )
+      end
+    end
+
+    context 'when passing Rack headers' do
+      let(:base) { URI.parse('http://example.com') }
+
+      it 'they are included in the request' do
+        response = browser.get('/foo', headers: {
+          'HTTP_FOO' => 'foo',
+          'HTTP_IF_NONE_MATCH' => 'qwerty',
+        })
+
+        expect(response.body).to eql(
+          <<~TEXT.chomp
+            http
+            example.com
+            /foo
+            http://example.com/foo
+            qwerty
+            foo
+          TEXT
+        )
       end
     end
   end

--- a/spec/parklife/build_spec.rb
+++ b/spec/parklife/build_spec.rb
@@ -2,6 +2,13 @@
 require 'parklife/build'
 
 RSpec.describe Parklife::Build do
+  def add(path, body)
+    build.add(
+      Parklife::Route.new(path, crawl: false),
+      Rack::MockResponse.new(200, {}, body)
+    )
+  end
+
   describe '.path_for' do
     [
       # Root paths are always saved as index.html.
@@ -83,21 +90,14 @@ RSpec.describe Parklife::Build do
     }
     let(:build_dir) { Dir.mktmpdir }
 
-    def add(path, body)
-      build.add(
-        Parklife::Route.new(path, crawl: false),
-        Rack::MockResponse.new(200, {}, body)
-      )
-    end
-
     context 'with a nested directory that does not exist' do
       let(:dir) { File.join(build_dir, 'nested') }
       let(:nested_index) { true }
 
       it 'creates the required directories' do
-        add('foo/bar/baz', '1')
-        add('foo/bar', '2')
-        add('foo', '3')
+        add('/foo/bar/baz', '1')
+        add('/foo/bar', '2')
+        add('/foo', '3')
 
         expect(build_files).to match_array([
           'nested/foo/index.html',
@@ -112,8 +112,8 @@ RSpec.describe Parklife::Build do
       let(:nested_index) { false }
 
       it do
-        add('foo', 'foo content')
-        add('bar', 'bar content')
+        add('/foo', 'foo content')
+        add('/bar', 'bar content')
 
         expect(build_files).to contain_exactly('bar.html', 'foo.html')
 
@@ -121,6 +121,37 @@ RSpec.describe Parklife::Build do
 
         expect(File.read(file_path)).to eql('bar content')
       end
+    end
+  end
+
+  describe '#to_yaml' do
+    let(:build) {
+      described_class.new(
+        Pathname.new(tmpdir),
+        nested_index: false,
+      )
+    }
+    let(:tmpdir) { Dir.mktmpdir }
+
+    it 'generates YAML with the expected shape' do
+      add('/foo', 'foo')
+      add('/bar', 'bar')
+
+      data = YAML.safe_load(build.to_yaml)
+
+      expect(data).to eql({
+        'config' => {
+          'nested_index' => false,
+        },
+        'paths' => {
+          '/foo' => {
+            'build_path' => 'foo.html',
+          },
+          '/bar' => {
+            'build_path' => 'bar.html',
+          },
+        },
+      })
     end
   end
 end

--- a/spec/parklife/build_spec.rb
+++ b/spec/parklife/build_spec.rb
@@ -2,11 +2,53 @@
 require 'parklife/build'
 
 RSpec.describe Parklife::Build do
-  def add(path, body)
+  let(:tmpdir) { Dir.mktmpdir }
+
+  def add(path, body, headers = {})
     build.add(
       Parklife::Route.new(path, crawl: false),
-      Rack::MockResponse.new(200, {}, body)
+      Rack::MockResponse.new(200, headers, body)
     )
+  end
+
+  describe '.from_dir' do
+    subject(:build) { described_class.from_dir(dir) }
+
+    context 'when everything is good and proper' do
+      let(:dir) { Pathname.new(tmpdir) }
+
+      it 'returns a Build pre-populated with data from .parklife/build.yml' do
+        existing_yaml = {
+          'config' => {
+            'nested_index' => false,
+          },
+          'paths' => {
+            '/foo' => {
+              'build_path' => 'foo.html',
+              'etag' => 'etag',
+            },
+          }
+        }.to_yaml
+
+        file = dir.join(Parklife::Build::META_PATH)
+        file.dirname.mkpath
+        file.write(existing_yaml)
+
+        expect(build.nested_index).to be(false)
+        expect(build.etag('/foo')).to eql('etag')
+        expect(build.to_yaml).to eql(existing_yaml)
+      end
+    end
+
+    context 'when the directory does not exist' do
+      let(:dir) { Pathname.new('nope') }
+      it { should be_nil }
+    end
+
+    context 'when the directory does not contain a metadata file' do
+      let(:dir) { Pathname.new(tmpdir) }
+      it { should be_nil }
+    end
   end
 
   describe '.path_for' do
@@ -134,7 +176,7 @@ RSpec.describe Parklife::Build do
     let(:tmpdir) { Dir.mktmpdir }
 
     it 'generates YAML with the expected shape' do
-      add('/foo', 'foo')
+      add('/foo', 'foo', { 'Etag' => 'etag' })
       add('/bar', 'bar')
 
       data = YAML.safe_load(build.to_yaml)
@@ -146,6 +188,7 @@ RSpec.describe Parklife::Build do
         'paths' => {
           '/foo' => {
             'build_path' => 'foo.html',
+            'etag' => 'etag',
           },
           '/bar' => {
             'build_path' => 'bar.html',

--- a/spec/parklife/crawler_spec.rb
+++ b/spec/parklife/crawler_spec.rb
@@ -1,10 +1,12 @@
+require 'digest'
+require 'tmpdir'
 require 'parklife/config'
 require 'parklife/crawler'
 require 'parklife/route_set'
-require 'tmpdir'
 
 RSpec.describe Parklife::Crawler do
   let(:build_dir) { Dir.mktmpdir }
+  let(:cache) { nil }
   let(:config) {
     Parklife::Config.new.tap { |config|
       config.app = app
@@ -21,7 +23,7 @@ RSpec.describe Parklife::Crawler do
   }
   let(:route_set) { Parklife::RouteSet.new }
 
-  subject { described_class.new(config, route_set) }
+  subject { described_class.new(config, route_set, cache) }
 
   after do
     FileUtils.remove_entry_secure(build_dir)
@@ -232,6 +234,64 @@ RSpec.describe Parklife::Crawler do
       index = File.join(build_dir, 'index.html')
 
       expect(File.read(index)).to eql("I'm a teapot")
+    end
+  end
+
+  context 'when a cache with matching path/ETag is present' do
+    let(:app) {
+      Proc.new { |env|
+        html = case env['PATH_INFO']
+        when '/'
+          '<a href="/foo">foo</a>'
+        when '/foo'
+          'foo'
+        else
+          'bar'
+        end
+
+        # It doesn't matter that this isn't a proper ETag, it's just a string.
+        etag = Digest::MD5.hexdigest(html)
+        headers = { 'etag' => etag }
+
+        if env['HTTP_IF_NONE_MATCH'] == etag
+          [304, headers, ['']]
+        else
+          [200, headers, [html]]
+        end
+      }
+    }
+    let(:cache) { Parklife::Build.new(config.cache_dir, nested_index: !config.nested_index) }
+    let(:cache_dir) { Dir.mktmpdir }
+    let(:cached_content) { '<a href="/bar">bar</a>' }
+
+    before do
+      config.cache_dir = cache_dir
+
+      cache.add(
+        Parklife::Route.new('/foo', crawl: true),
+        Rack::MockResponse.new(
+          200,
+          { 'etag' => Digest::MD5.hexdigest('foo') },
+          cached_content
+        )
+      )
+    end
+
+    it 'is used and crawled' do
+      route_set.get '/', crawl: true
+
+      subject.start
+
+      expect(build_files).to contain_exactly(
+        '.parklife/build.yml',
+        'bar/index.html', # This is only linked to from the cached content.
+        'foo/index.html',
+        'index.html',
+      )
+
+      expect(
+        subject.build.dir.join('foo/index.html').read
+      ).to eql(cached_content)
     end
   end
 end

--- a/spec/parklife/crawler_spec.rb
+++ b/spec/parklife/crawler_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Parklife::Crawler do
     FileUtils.remove_entry_secure(build_dir)
   end
 
-  context 'with standard config' do
+  context 'with default config' do
     let(:app) { endpoint_200 }
 
     it do
@@ -36,11 +36,26 @@ RSpec.describe Parklife::Crawler do
 
       subject.start
 
-      expect(build_files).to match_array(['foo/index.html', 'index.html'])
+      expect(build_files).to contain_exactly(
+        '.parklife/build.yml',
+        'foo/index.html',
+        'index.html',
+      )
 
       index = File.join(build_dir, 'index.html')
 
       expect(File.read(index)).to eql('200')
+    end
+  end
+
+  context 'when config.skip_build_meta=true' do
+    let(:app) { endpoint_200 }
+
+    it 'does not include metadata with the build' do
+      config.skip_build_meta = true
+      route_set.get '/foo'
+      subject.start
+      expect(build_files).to eql(['foo/index.html'])
     end
   end
 
@@ -57,12 +72,13 @@ RSpec.describe Parklife::Crawler do
 
       subject.start
 
-      expect(build_files).to match_array([
+      expect(build_files).to contain_exactly(
+        '.parklife/build.yml',
         'foo.html',
         'foo.xml',
         'index.html',
         'nested/foo.html',
-      ])
+      )
     end
   end
 
@@ -71,6 +87,7 @@ RSpec.describe Parklife::Crawler do
 
     it do
       config.base = 'https://foo.example.com'
+      config.skip_build_meta = true
 
       route_set.get '/'
 
@@ -90,7 +107,7 @@ RSpec.describe Parklife::Crawler do
     it 'the build still occurs' do
       subject.start
 
-      expect(build_files).to be_empty
+      expect(build_files).to eql(['.parklife/build.yml'])
     end
   end
 
@@ -122,14 +139,15 @@ RSpec.describe Parklife::Crawler do
 
       subject.start
 
-      expect(build_files).to match_array([
+      expect(build_files).to contain_exactly(
+        '.parklife/build.yml',
         'another/index.html',
         'bar/index.html',
         'baz/index.html',
         'foo/index.html',
         'index.html',
         'other/index.html',
-      ])
+      )
     end
   end
 
@@ -167,6 +185,7 @@ RSpec.describe Parklife::Crawler do
       subject.start
 
       expect(build_files).to match_array([
+        '.parklife/build.yml',
         'index.html',
         'foo/index.html',
         'bar/index.html',
@@ -202,6 +221,8 @@ RSpec.describe Parklife::Crawler do
     end
 
     it 'is used' do
+      config.skip_build_meta = true
+
       route_set.get '/'
 
       subject.start

--- a/spec/parklife/responder/not_modified_spec.rb
+++ b/spec/parklife/responder/not_modified_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+RSpec.describe Parklife::Responder::NotModified do
+  subject { described_class.new(crawler) }
+
+  let(:build_dir) { Dir.mktmpdir }
+  let(:config) {
+    c = Parklife::Config.new
+    c.build_dir = build_dir
+    c
+  }
+  let(:crawl) { false }
+  let(:crawler) { Parklife::Crawler.new(config, [], cache) }
+  let(:response) { Rack::MockResponse.new(304, {}, '') }
+  let(:route) { Parklife::Route.new('/foo', crawl: crawl) }
+
+  context 'when a valid cache is configured' do
+    let(:cache) { Parklife::Build.new(config.cache_dir, nested_index: config.nested_index) }
+    let(:cache_dir) { Dir.mktmpdir }
+
+    before do
+      config.cache_dir = cache_dir
+    end
+
+    context 'and it contains a matching route' do
+      before do
+        cache.add(
+          route,
+          Rack::MockResponse.new(200, {}, '<a href="/bar">bar</a> <a href="/baz">baz</a>')
+        )
+      end
+
+      context 'for a non-crawl route' do
+        it 'adds the response to the build' do
+          expect {
+            subject.call(route, response)
+          }.not_to change(crawler, :routes)
+
+          expect(build_files).to contain_exactly('foo/index.html')
+        end
+      end
+
+      context 'for a crawl route' do
+        let(:crawl) { true }
+
+        it 'adds the response to the build and adds discovered links to the crawler' do
+          expect {
+            subject.call(route, response)
+          }.to change(crawler, :routes).from([]).to([
+            Parklife::Route.new('/bar', crawl: true),
+            Parklife::Route.new('/baz', crawl: true),
+          ])
+
+          expect(build_files).to contain_exactly('foo/index.html')
+        end
+      end
+    end
+
+    context 'but it does not contain a matching route' do
+      before do
+        cache.add(
+          Parklife::Route.new('/another', crawl: false),
+          Rack::MockResponse.new(200, {}, 'foo')
+        )
+      end
+
+      it 'does nothing' do
+        expect {
+          subject.call(route, response)
+        }.not_to change(crawler, :routes)
+
+        expect(build_files).to be_empty
+      end
+    end
+  end
+
+  context 'when a cache is not configured' do
+    let(:cache) { nil }
+
+    it 'does nothing' do
+      expect {
+        subject.call(route, response)
+      }.not_to change(crawler, :routes)
+
+      expect(build_files).to be_empty
+    end
+  end
+end

--- a/spec/parklife/responder/ok_spec.rb
+++ b/spec/parklife/responder/ok_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Parklife::Responder::Ok do
     c.build_dir = build_dir
     c
   }
-  let(:crawler) { Parklife::Crawler.new(config, []) }
+  let(:crawler) { Parklife::Crawler.new(config, [], nil) }
   let(:response) { Rack::MockResponse.new(200, {}, '<a href="/bar">bar</a> <a href="/baz">baz</a>') }
 
   context 'with a non-crawl route' do


### PR DESCRIPTION
Parklife now saves build metadata (in the file `BUILD_DIR/.parklife/build.yml`) which is used to support HTTP caching via ETags (it can be skipped by setting the config `skip_build_meta = false` or using `--skip-build-meta` via the CLI). ETag generation and the actual cache hit/miss responsibility rests on the app itself but hopefully your framework can help with this (certainly Rails has lots of HTTP caching helpers). Tell Parklife to use a previous build as a cache source at build time with `parklife build --cache-dir build`.
